### PR TITLE
feat: implement assign mentors to trainees feature

### DIFF
--- a/src/app/protected/trainings/[trainingId]/staff/assign-mentors/AssignMentorsTable.tsx
+++ b/src/app/protected/trainings/[trainingId]/staff/assign-mentors/AssignMentorsTable.tsx
@@ -1,0 +1,145 @@
+"use client";
+import { useState, useTransition, useRef } from "react";
+import { Select, SelectTrigger, SelectContent, SelectItem } from "@/components/ui/select";
+import { CardContent } from "@/components/ui/card";
+
+interface Mentor {
+  userId: string;
+  username: string;
+  gmail: string;
+}
+interface Trainee {
+  userId: string;
+  mentorId: string;
+  username: string;
+  gmail: string;
+}
+
+export default function AssignMentorsTable({ trainees, mentors, trainingId }: { trainees: Trainee[]; mentors: Mentor[]; trainingId: number; }) {
+  const [isPending, startTransition] = useTransition();
+  const [selected, setSelected] = useState<string[]>([]);
+  const [bulkMentor, setBulkMentor] = useState<string | null>(null);
+  const lastClickedIndex = useRef<number | null>(null);
+
+  function toggleSelect(userId: string, index: number, shiftKey: boolean) {
+    if (shiftKey && lastClickedIndex.current !== null) {
+      const start = Math.min(lastClickedIndex.current, index);
+      const end = Math.max(lastClickedIndex.current, index);
+      const rangeIds = trainees.slice(start, end + 1).map(t => t.userId);
+      setSelected(prev => Array.from(new Set([...prev, ...rangeIds])));
+    } else {
+      setSelected((prev) => prev.includes(userId) ? prev.filter(id => id !== userId) : [...prev, userId]);
+    }
+    lastClickedIndex.current = index;
+  }
+  function selectAll() {
+    setSelected(trainees.map(t => t.userId));
+  }
+  function clearAll() {
+    setSelected([]);
+  }
+
+  async function handleAssign(traineeId: string, mentorId: string) {
+    startTransition(async () => {
+      await fetch(`/protected/trainings/${trainingId}/staff/assign-mentors/assign`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ traineeId, mentorId }),
+      });
+      window.location.reload();
+    });
+  }
+
+  async function handleBulkAssign() {
+    if (!bulkMentor) return;
+    const mentorId = bulkMentor;
+    startTransition(async () => {
+      await Promise.all(selected.map(traineeId =>
+        fetch(`/protected/trainings/${trainingId}/staff/assign-mentors/assign`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ traineeId, mentorId }),
+        })
+      ));
+      window.location.reload();
+    });
+  }
+
+  return (
+    <CardContent>
+      <div className="mb-2 flex items-center gap-2">
+        <button className="btn btn-xs border px-2 py-1 rounded" onClick={selectAll} disabled={isPending}>Select All</button>
+        <button className="btn btn-xs border px-2 py-1 rounded" onClick={clearAll} disabled={isPending}>Clear</button>
+        {selected.length > 0 && (
+          <div className="flex items-center gap-2 ml-4">
+            <span>Bulk assign to:</span>
+            <Select
+              value={bulkMentor ?? undefined}
+              onValueChange={setBulkMentor}
+              disabled={isPending}
+            >
+              <SelectTrigger className="w-40">{bulkMentor ? mentors.find(m => m.userId === bulkMentor)?.username : "Select Mentor"}</SelectTrigger>
+              <SelectContent className="max-h-60 overflow-y-auto">
+                {mentors.map((mentor) => (
+                  <SelectItem key={mentor.userId} value={mentor.userId}>
+                    {mentor.username} <span className="text-xs text-muted-foreground">({mentor.gmail})</span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <button className="btn btn-xs border px-2 py-1 rounded bg-primary text-primary-foreground" onClick={handleBulkAssign} disabled={isPending || !bulkMentor}>Apply</button>
+          </div>
+        )}
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full border">
+          <thead>
+            <tr>
+              <th className="px-2 py-2 border"><input type="checkbox" checked={selected.length === trainees.length && trainees.length > 0} onChange={e => e.target.checked ? selectAll() : clearAll()} /></th>
+              <th className="px-4 py-2 border">Trainee</th>
+              <th className="px-4 py-2 border">Current Mentor</th>
+              <th className="px-4 py-2 border">Assign Mentor</th>
+            </tr>
+          </thead>
+          <tbody>
+            {trainees.map((trainee, idx) => (
+              <tr key={trainee.userId} className={selected.includes(trainee.userId) ? "bg-muted" : ""}>
+                <td className="px-2 py-2 border text-center">
+                  <input
+                    type="checkbox"
+                    checked={selected.includes(trainee.userId)}
+                    onClick={e => toggleSelect(trainee.userId, idx, e.shiftKey)}
+                    readOnly
+                  />
+                </td>
+                <td className="px-4 py-2 border">{trainee.username} <span className="text-xs text-muted-foreground">({trainee.gmail})</span></td>
+                <td className="px-4 py-2 border">
+                  {mentors.find(m => m.userId === trainee.mentorId)?.username || <span className="text-muted-foreground">Unassigned</span>}
+                </td>
+                <td className="px-4 py-2 border">
+                  <Select
+                    name="mentorId"
+                    defaultValue={trainee.mentorId || undefined}
+                    onValueChange={mentorId => handleAssign(trainee.userId, mentorId)}
+                    disabled={isPending}
+                  >
+                    <SelectTrigger className="w-40">
+                      {mentors.find(m => m.userId === trainee.mentorId)?.username || "Select Mentor"}
+                    </SelectTrigger>
+                    <SelectContent className="max-h-60 overflow-y-auto">
+                      {mentors.map((mentor) => (
+                        <SelectItem key={mentor.userId} value={mentor.userId}>
+                          {mentor.username} <span className="text-xs text-muted-foreground">({mentor.gmail})</span>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </CardContent>
+  );
+} 

--- a/src/app/protected/trainings/[trainingId]/staff/assign-mentors/assign/route.ts
+++ b/src/app/protected/trainings/[trainingId]/staff/assign-mentors/assign/route.ts
@@ -1,0 +1,22 @@
+import { db } from "@/lib/db";
+import { Trainees } from "@/lib/db/schema/training/Trainees";
+import { eq, and } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request, { params }: { params: { trainingId: string } }) {
+  try {
+    const { traineeId, mentorId } = await req.json();
+    if (!mentorId) {
+      return NextResponse.json({ error: "Unassigning mentor is not supported." }, { status: 400 });
+    }
+    const trainingId = Number(params.trainingId);
+    await db
+      .update(Trainees)
+      .set({ mentorId })
+      .where(and(eq(Trainees.userId, traineeId), eq(Trainees.trainingId, trainingId)))
+      .execute();
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json({ error: "Failed to assign mentor" }, { status: 400 });
+  }
+} 

--- a/src/app/protected/trainings/[trainingId]/staff/assign-mentors/page.tsx
+++ b/src/app/protected/trainings/[trainingId]/staff/assign-mentors/page.tsx
@@ -1,0 +1,50 @@
+import { db } from "@/lib/db";
+import { Trainees } from "@/lib/db/schema/training/Trainees";
+import { Staff } from "@/lib/db/schema/training/Staff";
+import { Users } from "@/lib/db/schema/user/Users";
+import { eq, and } from "drizzle-orm";
+import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import AssignMentorsTable from "./AssignMentorsTable";
+
+export default async function AssignMentorsPage({ params }: { params: Promise<{ trainingId: string }> }) {
+  const { trainingId } = await params;
+  if (!trainingId) return <div>Invalid training ID</div>;
+
+  // Fetch all trainees for this training
+  const trainees = await db
+    .select({
+      userId: Trainees.userId,
+      mentorId: Trainees.mentorId,
+      username: Users.username,
+      gmail: Users.gmail,
+    })
+    .from(Trainees)
+    .where(eq(Trainees.trainingId, Number(trainingId)))
+    .innerJoin(Users, eq(Trainees.userId, Users.userId))
+    .execute();
+
+  // Fetch all mentors for this training
+  const mentors = await db
+    .select({
+      userId: Staff.userId,
+      username: Users.username,
+      gmail: Users.gmail,
+    })
+    .from(Staff)
+    .where(and(eq(Staff.trainingId, Number(trainingId)), eq(Staff.mentor, true)))
+    .innerJoin(Users, eq(Staff.userId, Users.userId))
+    .execute();
+
+  return (
+    <div className="min-h-screen bg-background py-8">
+      <div className="max-w-5xl mx-auto px-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-center text-2xl font-bold">Assign Mentors to Trainees</CardTitle>
+          </CardHeader>
+          <AssignMentorsTable trainees={trainees} mentors={mentors} trainingId={Number(trainingId)} />
+        </Card>
+      </div>
+    </div>
+  );
+} 

--- a/src/app/protected/trainings/[trainingId]/staff/mentors/actions/assignMentor.ts
+++ b/src/app/protected/trainings/[trainingId]/staff/mentors/actions/assignMentor.ts
@@ -1,0 +1,148 @@
+"use server";
+import "server-only";
+import { assignMentorSchema } from "@/lib/validation/training/assignMentor";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { and, eq, isNull } from "drizzle-orm";
+import { Users } from "@/lib/db/schema/user/Users";
+import { Staff } from "@/lib/db/schema/training/Staff";
+import { Trainees } from "@/lib/db/schema/training/Trainees";
+
+async function assignMentor(
+  input: z.infer<typeof assignMentorSchema>,
+): Promise<void> {
+  console.log("assignMentor called with:", input);
+  try {
+    // check if the validation is valid
+    assignMentorSchema.parse(input);
+
+    const { mentorUsername, traineeUsername, trainingId } = input;
+    // get userId from the database
+    const mentorUserId = (
+      await db
+        .select({ userId: Users.userId })
+        .from(Users)
+        .where(eq(Users.username, mentorUsername))
+    ).at(0)?.userId;
+
+    const traineeUserId = (
+      await db
+        .select({ userId: Users.userId })
+        .from(Users)
+        .where(eq(Users.username, traineeUsername))
+    ).at(0)?.userId;
+
+    console.log("Resolved mentorUserId:", mentorUserId, "traineeUserId:", traineeUserId);
+
+    if (!mentorUserId) {
+      console.error(`Mentor with username ${mentorUsername} not found.`);
+      throw new Error(`Mentor with username ${mentorUsername} not found.`);
+    }
+    if (!traineeUserId) {
+      console.error(`Trainee with username ${traineeUsername} not found.`);
+      throw new Error(`Trainee with username ${traineeUsername} not found.`);
+    }
+
+    if (
+      (
+        await db
+          .select({})
+          .from(Staff)
+          .where(
+            and(
+              eq(Staff.trainingId, trainingId),
+              eq(Staff.userId, mentorUserId),
+              isNull(Staff.deleted),
+              eq(Staff.mentor, true),
+            ),
+          )
+      ).length < 1
+    ) {
+      throw new Error(
+        `Mentor with username ${mentorUsername} is not assigned to this training.`,
+      );
+    }
+
+    if (
+      (
+        await db
+          .select({})
+          .from(Trainees)
+          .where(
+            and(
+              eq(Trainees.trainingId, trainingId),
+              eq(Trainees.userId, traineeUserId),
+              eq(Trainees.mentorId, mentorUserId),
+            ),
+          )
+      ).length >= 1
+    ) {
+      throw new Error(
+        `Trainee with username ${traineeUsername} is already assigned to mentor with username ${mentorUsername} in this training. or was assigned and deleted`,
+      );
+    }
+
+    if (
+      (
+        await db
+          .select({})
+          .from(Trainees)
+          .where(
+            and(
+              eq(Trainees.trainingId, trainingId),
+              eq(Trainees.userId, traineeUserId),
+              isNull(Trainees.deleted),
+            ),
+          )
+      ).length >= 1
+    ) {
+      throw new Error(
+        `Trainee with username ${traineeUsername} is already assigned to a mentor in this training`,
+      );
+    }
+
+    // Check if trainee already exists for this training
+    const existingTrainee = await db
+      .select({ userId: Trainees.userId })
+      .from(Trainees)
+      .where(
+        and(
+          eq(Trainees.trainingId, trainingId),
+          eq(Trainees.userId, traineeUserId),
+          isNull(Trainees.deleted),
+        )
+      )
+      .then(rows => rows[0]);
+
+    if (existingTrainee) {
+      console.log("Updating mentor for existing trainee:", traineeUserId, "to", mentorUserId);
+      await db.update(Trainees)
+        .set({ mentorId: mentorUserId })
+        .where(
+          and(
+            eq(Trainees.trainingId, trainingId),
+            eq(Trainees.userId, traineeUserId),
+            isNull(Trainees.deleted),
+          )
+        );
+    } else {
+      console.log("Inserting new trainee with mentor:", traineeUserId, mentorUserId);
+      await db.insert(Trainees).values({
+        userId: traineeUserId,
+        trainingId,
+        mentorId: mentorUserId,
+      });
+    }
+
+  } catch (error) {
+    console.error("assignMentor error:", error);
+    if (error instanceof z.ZodError) {
+      throw new Error(
+        `Validation error: ${error.errors.map((e) => e.message).join(", ")}`,
+      );
+    }
+    throw error;
+  }
+}
+
+export { assignMentor };

--- a/src/app/protected/trainings/[trainingId]/staff/mentors/actions/unassignMentor.ts
+++ b/src/app/protected/trainings/[trainingId]/staff/mentors/actions/unassignMentor.ts
@@ -1,0 +1,87 @@
+"use server";
+import "server-only";
+import { assignMentorSchema } from "@/lib/validation/training/assignMentor";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { and, eq, isNotNull, isNull, or } from "drizzle-orm";
+import { Users } from "@/lib/db/schema/user/Users";
+import { Staff } from "@/lib/db/schema/training/Staff";
+import { Trainees } from "@/lib/db/schema/training/Trainees";
+
+async function unassignMentor(
+  input: z.infer<typeof assignMentorSchema>,
+): Promise<void> {
+  try {
+    // check if the validation is valid
+    assignMentorSchema.parse(input);
+
+    const { mentorUsername, traineeUsername, trainingId } = input;
+    // get userId from the database
+    const mentorUserId = (
+      await db
+        .select({ userId: Users.userId })
+        .from(Users)
+        .where(eq(Users.username, mentorUsername))
+    ).at(0)?.userId;
+
+    const traineeUserId = (
+      await db
+        .select({ userId: Users.userId })
+        .from(Users)
+        .where(eq(Users.username, traineeUsername))
+    ).at(0)?.userId;
+
+    if (!mentorUserId) {
+      throw new Error(`Mentor with username ${mentorUsername} not found.`);
+    }
+    if (!traineeUserId) {
+      throw new Error(`Trainee with username ${traineeUsername} not found.`);
+    }
+
+
+    if (
+      (
+        await db
+          .select({})
+          .from(Trainees)
+          .where(
+            and(
+              eq(Trainees.trainingId, trainingId),
+              eq(Trainees.userId, traineeUserId),
+              eq(Trainees.mentorId, mentorUserId),
+              isNotNull(Trainees.deleted)
+            ),
+          )
+      ).length < 1
+    ) {
+      throw new Error(
+        `Trainee with username ${traineeUsername} is assigned to mentor ${mentorUsername} in this training.`,
+      );
+    }
+
+
+
+    // insert the trainee into the trainees table
+    await db.update(Trainees).set({
+      userId: traineeUserId,
+      trainingId,
+      mentorId: mentorUserId,
+      deleted: new Date(),
+    }).where(
+      and(
+        eq(Trainees.trainingId, trainingId),
+        eq(Trainees.userId, traineeUserId),
+        eq(Trainees.mentorId, mentorUserId),
+      ),
+    );
+
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new Error(
+        `Validation error: ${error.errors.map((e) => e.message).join(", ")}`,
+      );
+    }
+  }
+}
+
+export { unassignMentor };

--- a/src/components/training/TrainingNavigation.tsx
+++ b/src/components/training/TrainingNavigation.tsx
@@ -31,6 +31,7 @@ export async function TrainingNavigation({
     { perm: "View:contest", href: `/protected/trainings/${trainingId}/contests`, label: "Contests" },
     { perm: "View:standing", href: `/protected/trainings/${trainingId}/leaderboard`, label: "Leaderboard" },
     { perm: "Edit:staff", href: `/protected/trainings/${trainingId}/staff/staff-management`, label: "Staff Management" },
+    { perm: "Edit:staff", href: `/protected/trainings/${trainingId}/staff/assign-mentors`, label: "Assign Mentors" },
     { perm: "Edit:training", href: `/protected/trainings/${trainingId}/staff/edit-training`, label: "Edit Training" },
     { perm: "Edit:block", href: `/protected/trainings/${trainingId}/staff/edit-blocks`, label: "Edit Blocks" },
     { perm: "Edit:standing", href: `/protected/trainings/${trainingId}/staff/edit-standing-view`, label: "Standing View" },

--- a/src/lib/validation/training/assignMentor.ts
+++ b/src/lib/validation/training/assignMentor.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { username } from "../util";
+
+export const assignMentorSchema = z
+  .object({
+    mentorUsername: username.describe(
+      "The username of the mentor to be assigned to the trainee",
+    ),
+    traineeUsername: username.describe(
+      "The username of the trainee to whom the mentor is being assigned",
+    ),
+    trainingId: z.coerce
+      .number()
+      .int()
+      .positive()
+      .describe(
+        "The ID of the training session to which the mentor is being assigned",
+      ),
+  })
+  .describe("Schema for assigning a mentor to a trainee in a training session");


### PR DESCRIPTION
> Adds a feature for staff to assign mentors to trainees. Includes single and bulk (shift+click) selection of trainees and the ability to assign a mentor to multiple trainees at once.

![image](https://github.com/user-attachments/assets/1f3e56c8-d889-4d39-bd98-7385b332730f)
